### PR TITLE
fix: helperの読み込み位置を変更

### DIFF
--- a/example/usage-example.ts
+++ b/example/usage-example.ts
@@ -1,4 +1,4 @@
-import { UserHelper } from '../generated-helpers/UserHelper';
+import { UserHelper } from '../prisma/generated-helpers/UserHelper';
 
 (async () => {
   const user = await UserHelper.findById(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-relation-helper-generator",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Prisma generator to create Eloquent-like model helpers.",
   "author": "Shota Sakumoto",
   "license": "MIT",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,5 +22,5 @@ generator client {
 
 generator relationHelper {
   provider = "./dist/index.js"
-  output   = "../generated-helpers"
+  output   = "./generated-helpers"
 }


### PR DESCRIPTION
## インデントの調整

src/templates/helper.ejs のインデントを2スペースに統一し、コードの可読性を向上させました。

## 出力ディレクトリの変更

prisma/schema.prisma の generator relationHelper の output を "../generated-helpers" から "./generated-helpers" に変更し、生成されるヘルパーファイルの保存先を調整しました。

## importパスの修正

example/usage-example.ts の import 文を "../generated-helpers/UserHelper" から "../prisma/generated-helpers/UserHelper" に変更し、正しいパスでモジュールを読み込めるようにしました。
