### PR TITLE
fix: where クエリチェーンの実装 #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ yarn build
 yarn prisma generate
 ```
 
-generated-helpers/ ディレクトリに UserHelper.ts や ProfileHelper.ts が自動生成されます。
+./prisma/generated-helpers/ ディレクトリに UserHelper.ts や ProfileHelper.ts が自動生成されます。
 
 ## 使用例
 
 ```
-import { UserHelper } from './generated-helpers/UserHelper';
+import { UserHelper } from '../prisma/generated-helpers/UserHelper';
 
 (async () => {
   const user = await UserHelper.findById(1);

--- a/example/query-builder-example.ts
+++ b/example/query-builder-example.ts
@@ -1,0 +1,15 @@
+import { UserHelper } from '../prisma/generated-helpers/UserHelper';
+
+(async () => {
+  // 単一レコードの取得
+  const user = await UserHelper.where({ name: "Taro" }).first();
+  console.log('Single user:', user);
+
+  // 複数レコードの取得
+  const users = await UserHelper.where({ name: { contains: "Taro" } }).get();
+  console.log('Multiple users:', users);
+
+  // リレーションを含む取得
+  const userWithProfile = await UserHelper.where({ name: "Taro" }).first();
+  console.log('User with profile:', userWithProfile?.profile);
+})(); 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2,10 +2,10 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 async function main() {
-  // Profile を先に作成（user に紐づける）
-  const profile = await prisma.profile.create({
+  // テストユーザー1
+  const profile1 = await prisma.profile.create({
     data: {
-      image: 'https://example.com/image.jpg',
+      image: 'https://example.com/image1.jpg',
       user: {
         create: {
           name: 'テストユーザー'
@@ -17,7 +17,37 @@ async function main() {
     }
   });
 
-  console.log('Seeded profile:', profile);
+  // テストユーザー2（Taro）
+  const profile2 = await prisma.profile.create({
+    data: {
+      image: 'https://example.com/image2.jpg',
+      user: {
+        create: {
+          name: 'Taro'
+        }
+      }
+    },
+    include: {
+      user: true
+    }
+  });
+
+  // テストユーザー3（Taroを含む名前）
+  const profile3 = await prisma.profile.create({
+    data: {
+      image: 'https://example.com/image3.jpg',
+      user: {
+        create: {
+          name: 'Taro Yamada'
+        }
+      }
+    },
+    include: {
+      user: true
+    }
+  });
+
+  console.log('Seeded profiles:', { profile1, profile2, profile3 });
 }
 
 main()

--- a/src/templates/helper.ejs
+++ b/src/templates/helper.ejs
@@ -1,4 +1,39 @@
 // 自動生成されたヘルパー - <%= model.model %>
+import { PrismaClient, Prisma } from '@prisma/client';
+
+class <%= model.model %>QueryBuilder {
+  private prisma: PrismaClient;
+  private conditions: Prisma.<%= model.model %>WhereInput;
+  private includes: Record<string, boolean>;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+    this.conditions = {};
+    this.includes = {};
+    <% for (const rel of model.relations) { %>
+    this.includes['<%= rel %>'] = true;
+    <% } %>
+  }
+
+  where(conditions: Prisma.<%= model.model %>WhereInput): <%= model.model %>QueryBuilder {
+    this.conditions = conditions;
+    return this;
+  }
+
+  async first() {
+    return this.prisma.<%= model.model.toLowerCase() %>.findFirst({
+      where: this.conditions,
+      include: this.includes
+    });
+  }
+
+  async get() {
+    return this.prisma.<%= model.model.toLowerCase() %>.findMany({
+      where: this.conditions,
+      include: this.includes
+    });
+  }
+}
 
 export const <%= model.model %>Helper = {
   modelName: "<%= model.model %>",
@@ -15,5 +50,9 @@ export const <%= model.model %>Helper = {
         <% } %>
       }
     });
+  },
+
+  where(conditions: Prisma.<%= model.model %>WhereInput) {
+    return new <%= model.model %>QueryBuilder().where(conditions);
   }
 };


### PR DESCRIPTION
https://github.com/sakumoto-shota/prisma-relation-helper-generator/issues/1


## 下記を実装済み

-----

## 目標：UserHelper.where({ name: "Taro" }).first() のような呼び方

```
const user = await UserHelper.where({ name: "Taro" }).first();
```

## 必要な実装

`where(conditions: Prisma.UserWhereInput)` を実装

チェーン可能なクエリビルダークラス（例：UserQueryBuilder）を作る

first(), get()（複数取得）メソッドを追加

課題

型安全を Prisma に委譲（Prisma の where 条件型を使う