### PR TITLE
CRUD操作とsoftdeleteの対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@
 
 ---
 
+## 🆕 論理削除（soft delete）・CRUD強化
+
+- Prismaモデルに `deletedAt` フィールドを追加することで論理削除（soft delete）に自動対応
+- 生成されるHelper/QueryBuilderの `delete` メソッドで `enableSoftDelete`/`softDelete` フラグに応じて論理削除・物理削除を自動切り替え
+- `UserHelper` などのヘルパーオブジェクトに `enableSoftDelete` プロパティを追加し、`UserHelper.enableSoftDelete = true` で論理削除を有効化可能
+- example/extended/UserHelper.ts で `enableSoftDelete: true` をデフォルト有効化した拡張例を提供
+- テンプレート（helper.ejs）でUserHelper/QueryBuilderごとに適切なフラグ判定を行うよう分岐
+- generator.tsでテンプレートに `fields` を渡すことでdeletedAt判定の型安全性を向上
+- example配下の利用例で論理削除・物理削除の切り替え動作を確認可能
+
+---
+
 ## 📦 インストール
 
 ```bash

--- a/example/extended/UserHelper.ts
+++ b/example/extended/UserHelper.ts
@@ -11,8 +11,8 @@ export class UserQueryBuilder<
   active(): UserQueryBuilder<Include> {
     return this.where({ isActive: true }) as UserQueryBuilder<Include>;
   }
-  enableSoftDelete(): this {
-    super.enableSoftDelete();
+  setEnableSoftDelete(): this {
+    super.setEnableSoftDelete();
     return this;
   }
 }
@@ -27,17 +27,20 @@ export const UserHelper: UserHelperType = Object.assign({}, BaseUserHelper, {
   enableSoftDelete: true,
   where(conditions: Prisma.UserWhereInput): UserQueryBuilder<object> {
     const qb = new UserQueryBuilder().where(conditions);
-    if (UserHelper.enableSoftDelete) qb.enableSoftDelete();
-    return qb as UserQueryBuilder<object>;
+    if (UserHelper.enableSoftDelete)
+      (qb as unknown as UserQueryBuilder<object>).setEnableSoftDelete();
+    return qb as unknown as UserQueryBuilder<object>;
   },
   with(relations: (keyof Prisma.UserInclude)[]): UserQueryBuilder<object> {
     const qb = new UserQueryBuilder().with(relations);
-    if (UserHelper.enableSoftDelete) qb.enableSoftDelete();
+    if (UserHelper.enableSoftDelete)
+      (qb as unknown as UserQueryBuilder<object>).setEnableSoftDelete();
     return qb as unknown as UserQueryBuilder<object>;
   },
   active(): UserQueryBuilder<object> {
     const qb = new UserQueryBuilder().active();
-    if (UserHelper.enableSoftDelete) qb.enableSoftDelete();
-    return qb;
+    if (UserHelper.enableSoftDelete)
+      (qb as unknown as UserQueryBuilder<object>).setEnableSoftDelete();
+    return qb as unknown as UserQueryBuilder<object>;
   },
 });

--- a/example/extended/UserHelper.ts
+++ b/example/extended/UserHelper.ts
@@ -11,20 +11,33 @@ export class UserQueryBuilder<
   active(): UserQueryBuilder<Include> {
     return this.where({ isActive: true }) as UserQueryBuilder<Include>;
   }
+  enableSoftDelete(): this {
+    super.enableSoftDelete();
+    return this;
+  }
 }
 
 // UserHelperを拡張
-export const UserHelper = {
-  ...BaseUserHelper,
+type UserHelperType = typeof BaseUserHelper & {
+  enableSoftDelete: boolean;
+  active: () => UserQueryBuilder<object>;
+};
+
+export const UserHelper: UserHelperType = Object.assign({}, BaseUserHelper, {
+  enableSoftDelete: true,
   where(conditions: Prisma.UserWhereInput): UserQueryBuilder<object> {
-    return new UserQueryBuilder().where(conditions) as UserQueryBuilder<object>;
+    const qb = new UserQueryBuilder().where(conditions);
+    if (UserHelper.enableSoftDelete) qb.enableSoftDelete();
+    return qb as UserQueryBuilder<object>;
   },
   with(relations: (keyof Prisma.UserInclude)[]): UserQueryBuilder<object> {
-    return new UserQueryBuilder().with(
-      relations,
-    ) as unknown as UserQueryBuilder<object>;
+    const qb = new UserQueryBuilder().with(relations);
+    if (UserHelper.enableSoftDelete) qb.enableSoftDelete();
+    return qb as unknown as UserQueryBuilder<object>;
   },
   active(): UserQueryBuilder<object> {
-    return new UserQueryBuilder().active();
+    const qb = new UserQueryBuilder().active();
+    if (UserHelper.enableSoftDelete) qb.enableSoftDelete();
+    return qb;
   },
-};
+});

--- a/example/query-builder-example.ts
+++ b/example/query-builder-example.ts
@@ -1,29 +1,32 @@
-import { UserHelper } from '../prisma/generated-helpers/UserHelper';
 import { prisma } from '../src/prisma-client';
 import { UserHelper as ExtendedUserHelper } from './extended/UserHelper';
 
 (async (): Promise<void> => {
   try {
     // 単一レコードの取得
-    const user = await UserHelper.where({ name: 'Taro' }).first();
+    const user = await ExtendedUserHelper.where({ name: 'Taro' }).first();
     console.log('Single user:', user);
 
     // 複数レコードの取得
-    const users = await UserHelper.where({ name: { contains: 'Taro' } }).get();
+    const users = await ExtendedUserHelper.where({
+      name: { contains: 'Taro' },
+    }).get();
     console.log('Multiple users:', users);
 
     // リレーションを含む取得
-    const userAndProfile = await UserHelper.where({ name: 'Taro' }).first();
+    const userAndProfile = await ExtendedUserHelper.where({
+      name: 'Taro',
+    }).first();
     console.log('User and profile:', userAndProfile?.profile);
 
     // リレーションを含むeager loading取得
-    const userWithProfile = await UserHelper.with('profile')
+    const userWithProfile = await ExtendedUserHelper.with('profile')
       .where({ name: 'Taro' })
       .first();
     console.log('User with profile:', userWithProfile?.profile);
 
     // createdAt昇順
-    const usersAsc = await UserHelper.where({})
+    const usersAsc = await ExtendedUserHelper.where({})
       .orderBy('createdAt', 'asc')
       .get();
     console.log(
@@ -32,7 +35,7 @@ import { UserHelper as ExtendedUserHelper } from './extended/UserHelper';
     );
 
     // createdAt降順
-    const usersDesc = await UserHelper.where({})
+    const usersDesc = await ExtendedUserHelper.where({})
       .orderBy('createdAt', 'desc')
       .get();
     console.log(
@@ -46,6 +49,21 @@ import { UserHelper as ExtendedUserHelper } from './extended/UserHelper';
       'Active users:',
       activeUsers.map((u) => ({ name: u.name, isActive: u.isActive })),
     );
+
+    // --- CRUD操作の例 ---
+    // 追加
+    const createdUser = await ExtendedUserHelper.create({ name: 'NewUser' });
+    console.log('Created user:', createdUser);
+
+    // 更新
+    const updatedUser = await ExtendedUserHelper.update(createdUser.id, {
+      name: 'UpdatedUser',
+    });
+    console.log('Updated user:', updatedUser);
+
+    // 削除
+    const deletedUser = await ExtendedUserHelper.delete(createdUser.id);
+    console.log('Deleted user:', deletedUser);
   } catch (error) {
     console.error('Error:', error);
   } finally {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-relation-helper-generator",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A Prisma generator to create Eloquent-like model helpers.",
   "author": "Shota Sakumoto",
   "license": "MIT",

--- a/prisma/migrations/20250510133543_add_deleted_at_to_user/migration.sql
+++ b/prisma/migrations/20250510133543_add_deleted_at_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "deletedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,10 +4,11 @@ datasource db {
 }
 
 model User {
-  id        Int      @id @default(autoincrement())
+  id        Int       @id @default(autoincrement())
   name      String
-  createdAt DateTime @default(now())
-  isActive  Boolean  @default(true)
+  createdAt DateTime  @default(now())
+  isActive  Boolean   @default(true)
+  deletedAt DateTime?
   profile   Profile?
   posts     Post[]
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -31,7 +31,7 @@ export async function generate(
 
     // テンプレートをレンダリング
     const content = ejs.render(template, {
-      model: { model: model.name, relations },
+      model: { model: model.name, relations, fields: model.fields },
     });
 
     // ファイルに書き出し（非同期）

--- a/src/templates/helper.ejs
+++ b/src/templates/helper.ejs
@@ -169,5 +169,3 @@ export const <%= model.model %>Helper = {
     return new <%= model.model %>QueryBuilder().with(relations);
   },
 };
-
-<% console.log(model.fields) %>

--- a/src/templates/helper.ejs
+++ b/src/templates/helper.ejs
@@ -7,7 +7,7 @@ export class <%= model.model %>QueryBuilder<Include extends Prisma.<%= model.mod
   private includes: Include = {} as Include;
   private conditions: Prisma.<%= model.model %>WhereInput = {};
   private order: Prisma.<%= model.model %>OrderByWithRelationInput[] = [];
-  private softDelete: boolean = false;
+  private enableSoftDelete: boolean = false;
 
   // モデルごとの全リレーション名
   static allRelations = [<% model.relations.forEach((relation, index) => { %>'<%= relation %>'<%= index < model.relations.length - 1 ? ', ' : '' %><% }); %>];
@@ -47,14 +47,14 @@ export class <%= model.model %>QueryBuilder<Include extends Prisma.<%= model.mod
     return this;
   }
 
-  enableSoftDelete(): this {
-    this.softDelete = true;
+  setEnableSoftDelete(): this {
+    this.enableSoftDelete = true;
     return this;
   }
 
   async first(): Promise<Prisma.<%= model.model %>GetPayload<{ include: Prisma.<%= model.model %>Include }> | null> {
     const where: Prisma.<%= model.model %>WhereInput = { ...this.conditions };
-    if (this.softDelete) {
+    if (this.enableSoftDelete) {
       Object.assign(where, { deletedAt: null });
     }
     return prisma.<%= model.model.toLowerCase() %>.findFirst({
@@ -66,7 +66,7 @@ export class <%= model.model %>QueryBuilder<Include extends Prisma.<%= model.mod
 
   async get(): Promise<Prisma.<%= model.model %>GetPayload<{ include: Prisma.<%= model.model %>Include }>[]> {
     const where: Prisma.<%= model.model %>WhereInput = { ...this.conditions };
-    if (this.softDelete) {
+    if (this.enableSoftDelete) {
       Object.assign(where, { deletedAt: null });
     }
     return prisma.<%= model.model.toLowerCase() %>.findMany({
@@ -78,7 +78,7 @@ export class <%= model.model %>QueryBuilder<Include extends Prisma.<%= model.mod
 
   async findById(id: number): Promise<Prisma.<%= model.model %>GetPayload<{ include: Prisma.<%= model.model %>Include }> | null> {
     const where: Prisma.<%= model.model %>WhereUniqueInput & { deletedAt?: null } = { id };
-    if (this.softDelete) {
+    if (this.enableSoftDelete) {
       where.deletedAt = null;
     }
     return prisma.<%= model.model.toLowerCase() %>.findUnique({
@@ -94,7 +94,7 @@ export class <%= model.model %>QueryBuilder<Include extends Prisma.<%= model.mod
 
   async delete(id: number): Promise<<%= model.model %>> {
 <% if (model.fields && model.fields.some(f => f.name === 'deletedAt')) { %>
-    if (this.softDelete) {
+    if (this.enableSoftDelete) {
       // 論理削除
       return prisma.<%= model.model.toLowerCase() %>.update({
         where: { id },

--- a/src/templates/helper.ejs
+++ b/src/templates/helper.ejs
@@ -1,5 +1,5 @@
 // 自動生成されたヘルパー - <%= model.model %>
-import { Prisma } from '@prisma/client';
+import { Prisma, <%= model.model %> } from '@prisma/client';
 // PrismaClientSingletonの共通モジュールをインポート
 import { prisma } from '../../src/prisma-client';
 
@@ -7,6 +7,7 @@ export class <%= model.model %>QueryBuilder<Include extends Prisma.<%= model.mod
   private includes: Include = {} as Include;
   private conditions: Prisma.<%= model.model %>WhereInput = {};
   private order: Prisma.<%= model.model %>OrderByWithRelationInput[] = [];
+  private softDelete: boolean = false;
 
   // モデルごとの全リレーション名
   static allRelations = [<% model.relations.forEach((relation, index) => { %>'<%= relation %>'<%= index < model.relations.length - 1 ? ', ' : '' %><% }); %>];
@@ -46,25 +47,42 @@ export class <%= model.model %>QueryBuilder<Include extends Prisma.<%= model.mod
     return this;
   }
 
+  enableSoftDelete(): this {
+    this.softDelete = true;
+    return this;
+  }
+
   async first(): Promise<Prisma.<%= model.model %>GetPayload<{ include: Prisma.<%= model.model %>Include }> | null> {
+    const where: Prisma.<%= model.model %>WhereInput = { ...this.conditions };
+    if (this.softDelete) {
+      Object.assign(where, { deletedAt: null });
+    }
     return prisma.<%= model.model.toLowerCase() %>.findFirst({
-      where: this.conditions,
+      where,
       include: this.getIncludeWithDefaults(),
       orderBy: this.order.length > 0 ? this.order : undefined,
     });
   }
 
   async get(): Promise<Prisma.<%= model.model %>GetPayload<{ include: Prisma.<%= model.model %>Include }>[]> {
+    const where: Prisma.<%= model.model %>WhereInput = { ...this.conditions };
+    if (this.softDelete) {
+      Object.assign(where, { deletedAt: null });
+    }
     return prisma.<%= model.model.toLowerCase() %>.findMany({
-      where: this.conditions,
+      where,
       include: this.getIncludeWithDefaults(),
       orderBy: this.order.length > 0 ? this.order : undefined,
     });
   }
 
   async findById(id: number): Promise<Prisma.<%= model.model %>GetPayload<{ include: Prisma.<%= model.model %>Include }> | null> {
+    const where: Prisma.<%= model.model %>WhereUniqueInput & { deletedAt?: null } = { id };
+    if (this.softDelete) {
+      where.deletedAt = null;
+    }
     return prisma.<%= model.model.toLowerCase() %>.findUnique({
-      where: { id },
+      where,
       include: this.getIncludeWithDefaults(),
     });
   }
@@ -73,11 +91,67 @@ export class <%= model.model %>QueryBuilder<Include extends Prisma.<%= model.mod
     this.conditions = conditions;
     return this;
   }
+
+  async delete(id: number): Promise<<%= model.model %>> {
+<% if (model.fields && model.fields.some(f => f.name === 'deletedAt')) { %>
+    if (this.softDelete) {
+      // 論理削除
+      return prisma.<%= model.model.toLowerCase() %>.update({
+        where: { id },
+        data: { deletedAt: new Date() },
+      });
+    } else {
+      // 物理削除
+      return prisma.<%= model.model.toLowerCase() %>.delete({
+        where: { id },
+      });
+    }
+<% } else { %>
+    // 物理削除
+    return prisma.<%= model.model.toLowerCase() %>.delete({
+      where: { id },
+    });
+<% } %>
+  }
 }
 
 export const <%= model.model %>Helper = {
   modelName: '<%= model.model %>',
   relations: [<% model.relations.forEach((relation, index) => { %>'<%= relation %>'<%= index < model.relations.length - 1 ? ', ' : '' %><% }); %>],
+  enableSoftDelete: false,
+
+  async create(data: Prisma.<%= model.model %>CreateInput): Promise<<%= model.model %>> {
+    return prisma.<%= model.model.toLowerCase() %>.create({ data });
+  },
+
+  async update(id: number, data: Prisma.<%= model.model %>UpdateInput): Promise<<%= model.model %>> {
+    return prisma.<%= model.model.toLowerCase() %>.update({
+      where: { id },
+      data,
+    });
+  },
+
+  async delete(id: number): Promise<<%= model.model %>> {
+<% if (model.fields && model.fields.some(f => f.name === 'deletedAt')) { %>
+    if (this.enableSoftDelete) {
+      // 論理削除
+      return prisma.<%= model.model.toLowerCase() %>.update({
+        where: { id },
+        data: { deletedAt: new Date() },
+      });
+    } else {
+      // 物理削除
+      return prisma.<%= model.model.toLowerCase() %>.delete({
+        where: { id },
+      });
+    }
+<% } else { %>
+    // 物理削除
+    return prisma.<%= model.model.toLowerCase() %>.delete({
+      where: { id },
+    });
+<% } %>
+  },
 
   async findById(id: number): Promise<Prisma.<%= model.model %>GetPayload<{ include: { <% model.relations.forEach((relation, index) => { %><%= relation %>: true<%= index < model.relations.length - 1 ? ', ' : '' %><% }); %> } }> | null> {
     return prisma.<%= model.model.toLowerCase() %>.findUnique({
@@ -95,3 +169,5 @@ export const <%= model.model %>Helper = {
     return new <%= model.model %>QueryBuilder().with(relations);
   },
 };
+
+<% console.log(model.fields) %>


### PR DESCRIPTION
## 概要

`feature/add-crud-and-softdelete` ブランチでは、Prismaモデルの論理削除（soft delete）対応とCRUD機能の強化を中心に、テンプレート・生成物・example拡張に多数の修正を加えました。

---

## 主な修正内容

### 1. 論理削除（soft delete）対応
- PrismaスキーマのUserモデルに `deletedAt: DateTime?` フィールドを追加。
- ヘルパージェネレーターのテンプレート（`helper.ejs`）を修正し、`deletedAt` フィールドが存在する場合のみ論理削除を有効化。
- `UserHelper`/`UserQueryBuilder` の `delete` メソッドで、`enableSoftDelete`/`softDelete` フラグに応じて論理削除（`deletedAt`に日付をセット）と物理削除を自動で切り替え。

### 2. enableSoftDeleteフラグの導入
- 生成される `UserHelper` オブジェクトに `enableSoftDelete` プロパティを追加。
- `enableSoftDelete` を `true` にすることで、`UserHelper.delete` で論理削除が有効化される設計に。
- example拡張（`example/extended/UserHelper.ts`）でもデフォルトで `enableSoftDelete: true` をセット。

### 3. テンプレートの型安全・分岐強化
- `UserQueryBuilder` クラスの `delete` では `this.softDelete`、`UserHelper` オブジェクトの `delete` では `this.enableSoftDelete` を判定するようテンプレートを分岐。
- `model.fields` の判定が正しく動作するよう、ジェネレーター側で `fields` をテンプレートに渡すよう修正。

### 4. example/extended での拡張
- `UserHelper` を拡張し、`active()` などのカスタムクエリや `enableSoftDelete` のデフォルト有効化を実装。
- example配下の利用例で論理削除・物理削除の切り替え動作を確認可能に。

### 5. その他
- テンプレートのリファクタリング・コメント追加。
- 生成物の型エラーやESLintエラーの解消。
- READMEやexampleの説明も随時更新。

---

## 影響範囲

- 生成される各モデルのヘルパー（`UserHelper.ts` など）
- example/extended配下の拡張例
- Prismaスキーマ（`schema.prisma`）のUserモデル
- テンプレート（`src/templates/helper.ejs`）
- ジェネレーター本体（`src/generator.ts`）

---

## マイグレーション・利用上の注意

- Prismaスキーマに `deletedAt` を追加した場合は、必ず `prisma migrate dev` などでDBスキーマを更新してください。
- `enableSoftDelete` のデフォルト値や切り替えタイミングに注意してください（グローバルに効きます）。

---

## 関連ファイル

- `prisma/schema.prisma`
- `src/templates/helper.ejs`
- `src/generator.ts`
- `prisma/generated-helpers/UserHelper.ts` など
- `example/extended/UserHelper.ts`
- `example/query-builder-example.ts`