### PR TITLE
fix: npm 公開の準備

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+# Node.js
+node_modules/
+
+# Env files
+.env
+.env.*
+
+# IDEs
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 ```bash
 yarn add -D prisma-relation-helper-generator
-※ 現在はローカル開発中。npm パブリッシュ後、正式版をインストール可能になります。
+# npmの場合: npm install --save-dev prisma-relation-helper-generator
 ```
 
 ## 📝 Prisma schema.prisma 設定例
@@ -52,7 +52,7 @@ generator client {
 
 generator relationHelper {
   provider = "./dist/index.js"
-  output   = "./generated-helpers"
+  output   = "./dist/generated-helpers"
 }
 
 model User {
@@ -83,12 +83,12 @@ yarn build
 yarn prisma generate
 ```
 
-./prisma/generated-helpers/ ディレクトリに UserHelper.ts や ProfileHelper.ts が自動生成されます。
+`./dist/generated-helpers/` ディレクトリに UserHelper.ts や ProfileHelper.ts が自動生成されます。
 
 ## 使用例
 
 ```ts
-import { UserHelper } from '../prisma/generated-helpers/UserHelper';
+import { UserHelper } from '../dist/generated-helpers/UserHelper';
 
 (async () => {
   // 単一レコードの取得

--- a/__tests__/UserHelper.test.ts
+++ b/__tests__/UserHelper.test.ts
@@ -7,7 +7,7 @@ import {
   beforeEach,
   afterEach,
 } from 'vitest';
-import { UserHelper } from '../prisma/generated-helpers/UserHelper';
+import { UserHelper } from '../dist/generated-helpers/UserHelper';
 import { prisma } from '../src/prisma-client';
 
 beforeAll(async () => {

--- a/example/extended/UserHelper.ts
+++ b/example/extended/UserHelper.ts
@@ -1,7 +1,7 @@
 import {
   UserHelper as BaseUserHelper,
   UserQueryBuilder as BaseUserQueryBuilder,
-} from '../../prisma/generated-helpers/UserHelper';
+} from '../../dist/generated-helpers/UserHelper';
 import { Prisma } from '@prisma/client';
 
 // UserQueryBuilderを拡張

--- a/example/usage-example.ts
+++ b/example/usage-example.ts
@@ -1,4 +1,4 @@
-import { UserHelper } from '../prisma/generated-helpers/UserHelper';
+import { UserHelper } from '../dist/generated-helpers/UserHelper';
 
 (async (): Promise<void> => {
   const user = await UserHelper.findById(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-relation-helper-generator",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A Prisma generator to create Eloquent-like model helpers.",
   "author": "Shota Sakumoto",
   "license": "MIT",
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist generated-helpers",
-    "build": "yarn clean && tsc && cp -R src/templates dist/templates && node ./add-shebang.js",
+    "build": "yarn clean && tsc && cp -R src/templates dist/templates && mkdir -p dist/generated-helpers && node ./add-shebang.js",
     "seed": "npx ts-node prisma/seed.ts",
     "generate": "yarn build && yarn prisma generate && yarn lint:fix",
     "lint": "eslint . --ext .ts",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist generated-helpers",
-    "build": "yarn clean && tsc && cp -R src/templates dist/templates && mkdir -p dist/generated-helpers && node ./add-shebang.js",
+    "build": "yarn clean && tsc && cp -R src/templates dist/templates && mkdir -p dist/generated-helpers && node ./add-shebang.js && yarn prisma generate ",
     "seed": "npx ts-node prisma/seed.ts",
     "generate": "yarn build && yarn prisma generate && yarn lint:fix",
     "lint": "eslint . --ext .ts",
@@ -48,5 +48,10 @@
     "eloquent",
     "relation",
     "typescript"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-relation-helper-generator",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A Prisma generator to create Eloquent-like model helpers.",
   "author": "Shota Sakumoto",
   "license": "MIT",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,5 +34,5 @@ generator client {
 
 generator relationHelper {
   provider = "./dist/index.js"
-  output   = "./generated-helpers"
+  output   = "../dist/generated-helpers"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,15 +6,15 @@ import { generate } from './generator';
 generatorHandler({
   onManifest() {
     return {
-      defaultOutput: './generated-helpers',
+      defaultOutput: './dist/generated-helpers',
       prettyName: 'Prisma Relation Helper Generator',
     };
   },
   async onGenerate(options: GeneratorOptions) {
     const models = parseRelations([...options.dmmf.datamodel.models]);
 
-    const outputPath = options.generator.output?.value || './generated-helpers';
-
+    const outputPath =
+      options.generator.output?.value || './dist/generated-helpers';
     await generate(models, outputPath);
   },
 });


### PR DESCRIPTION
## 概要

- Prismaリレーションヘルパーの生成先を `dist/generated-helpers` 配下に統一しました。
- exampleコード（`usage-example.ts`, `extended/UserHelper.ts` など）のimportパスも `dist/generated-helpers` を参照するよう修正しました。

## 主な変更点

- Prisma generatorの `output` を `./dist/generated-helpers` に変更
- `src/index.ts` でのデフォルト出力先も `./dist/generated-helpers` に修正
- example配下の各ファイルで、`UserHelper` などのimportパスを `dist/generated-helpers` 参照に統一
- これにより、npmパッケージ配布時や本番利用時も `dist` 配下のみで完結する構成となります

## 補足

- exampleの一部（`query-builder-example.ts`）は拡張用の `extended/UserHelper.ts` を参照する形にしています
- 今後は `dist` 配下のみでexampleやテストが動作するため、npm公開・配布の運用が容易になります
