### PR TITLE
[type-puzzle] fix nested include typing

### DIFF
--- a/src/include-types.ts
+++ b/src/include-types.ts
@@ -1,0 +1,18 @@
+export type IncludeFromPaths<Paths extends string> =
+  Paths extends `${infer First}.${infer Rest}`
+    ? { [K in First]: { include: IncludeFromPaths<Rest> } }
+    : { [K in Paths]: true };
+export type MergeIncludes<A, B> = {
+  [K in keyof A | keyof B]: K extends keyof B
+    ? B[K]
+    : K extends keyof A
+      ? A[K]
+      : never;
+};
+
+export type IncludesFromArray<Arr extends readonly string[]> = Arr extends [
+  infer First extends string,
+  ...infer Rest extends string[],
+]
+  ? MergeIncludes<IncludeFromPaths<First>, IncludesFromArray<Rest>>
+  : {};

--- a/src/templates/helper.ejs
+++ b/src/templates/helper.ejs
@@ -1,5 +1,6 @@
 // 自動生成されたヘルパー - <%= model.model %>
 import { Prisma, <%= model.model %> } from '@prisma/client';
+import type { IncludesFromArray } from '../../src/include-types';
 // PrismaClientSingletonの共通モジュールをインポート
 import { prisma } from '../../src/prisma-client';
 
@@ -27,7 +28,7 @@ export class <%= model.model %>QueryBuilder<Include extends Prisma.<%= model.mod
    * リレーションを動的に指定する（型安全）
    * @param relations Prisma.<%= model.model %>Includeのキーまたは配列
    */
-  with(relations: string | string[]): this {
+  with<Paths extends string>(relations: Paths | Paths[]): <%= model.model %>QueryBuilder<Include & IncludesFromArray<Paths[]>> {
     const add = (path: string): void => {
       const parts = path.split('.');
       let target = this.includes as unknown as Record<string, unknown>;
@@ -49,7 +50,7 @@ export class <%= model.model %>QueryBuilder<Include extends Prisma.<%= model.mod
     } else {
       add(relations);
     }
-    return this;
+    return this as unknown as <%= model.model %>QueryBuilder<Include & IncludesFromArray<Paths[]>>;
   }
 
   orderBy(column: keyof Prisma.<%= model.model %>OrderByWithRelationInput, direction: 'asc' | 'desc'): this {
@@ -62,7 +63,7 @@ export class <%= model.model %>QueryBuilder<Include extends Prisma.<%= model.mod
     return this;
   }
 
-  async first(): Promise<Prisma.<%= model.model %>GetPayload<{ include: Prisma.<%= model.model %>Include }> | null> {
+  async first(): Promise<Prisma.<%= model.model %>GetPayload<{ include: Include }> | null> {
     const where: Prisma.<%= model.model %>WhereInput = { ...this.conditions };
     if (this.enableSoftDelete) {
       Object.assign(where, { deletedAt: null });
@@ -74,7 +75,7 @@ export class <%= model.model %>QueryBuilder<Include extends Prisma.<%= model.mod
     });
   }
 
-  async get(): Promise<Prisma.<%= model.model %>GetPayload<{ include: Prisma.<%= model.model %>Include }>[]> {
+  async get(): Promise<Prisma.<%= model.model %>GetPayload<{ include: Include }>[]> {
     const where: Prisma.<%= model.model %>WhereInput = { ...this.conditions };
     if (this.enableSoftDelete) {
       Object.assign(where, { deletedAt: null });
@@ -86,7 +87,7 @@ export class <%= model.model %>QueryBuilder<Include extends Prisma.<%= model.mod
     });
   }
 
-  async findById(id: number): Promise<Prisma.<%= model.model %>GetPayload<{ include: Prisma.<%= model.model %>Include }> | null> {
+  async findById(id: number): Promise<Prisma.<%= model.model %>GetPayload<{ include: Include }> | null> {
     const where: Prisma.<%= model.model %>WhereUniqueInput & { deletedAt?: null } = { id };
     if (this.enableSoftDelete) {
       where.deletedAt = null;
@@ -175,7 +176,7 @@ export const <%= model.model %>Helper = {
   where(conditions: Prisma.<%= model.model %>WhereInput): <%= model.model %>QueryBuilder {
     return new <%= model.model %>QueryBuilder().where(conditions);
   },
-  with(relations: string | string[]): <%= model.model %>QueryBuilder<object> {
-    return new <%= model.model %>QueryBuilder().with(relations);
+  with<Paths extends string>(relations: Paths | Paths[]): <%= model.model %>QueryBuilder<IncludesFromArray<Paths[]>> {
+    return new <%= model.model %>QueryBuilder<IncludesFromArray<Paths[]>>().with(relations);
   },
 };


### PR DESCRIPTION
## 概要（日本語）

このPRでは、`with()` メソッドから `findById` までの型を見直し、ネストしたリレーション (`posts.threads` など) を指定した際にも型エラーが出ないようにしました。

- `src/include-types.ts` を新規追加し、文字列パスから `include` オブジェクト型を生成
- `helper.ejs` 内で `with` メソッドと返り値型を修正し、ネストリレーションに対応

---

## QA確認したこと（ローカルでの確認）

- [ ] 型エラーが発生しないこと（VSCode上で確認）
- [ ] `package.json` に必要な依存が追加されていること
- [ ] 出力された設定ファイル（例: `.eslintrc.js`, `tsconfig.json`）が意図通りであること
- [ ] **ビルド・テストは実行していません（Codex制約上）**

---

## レビューアーに確認して欲しいこと

- [ ] 型定義の設計が妥当か
- [ ] 不要なコード・依存が含まれていないか
- [ ] コード品質
- [ ] Codexの制約に従っているか

---

## その他（Codexへの補足：自動生成系）

- 実行不可能な処理は含まれていません
- 外部APIアクセスはありません